### PR TITLE
When deleting a SecureConnectToken, ignore creation of a DeletedModel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- nothing added
+- When deleting a SecureConnectToken, ignore creation of a DeletedModel.
+- Added a setting IGNORED_MODELS_ON_DELETE for the models to ignore when deleting.
 
 ### Changed
 

--- a/concrete_datastore/concrete/automation/signal_processor.py
+++ b/concrete_datastore/concrete/automation/signal_processor.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-
+from django.conf import settings
 from django.dispatch import receiver
 from django.db.models.signals import pre_delete, post_save
 from django.contrib.auth import get_user_model
@@ -13,13 +13,13 @@ from concrete_datastore.api.v1.views import (
 
 @receiver(pre_delete)
 def on_pre_delete(sender, instance, **kwargs):
-    if hasattr(
-        concrete_datastore.concrete.models, instance.__class__.__name__
-    ) and instance.__class__.__name__ not in [
-        "DeletedModel",
-        "AuthToken",
-        "TemporaryToken",
-    ]:
+    if (
+        hasattr(
+            concrete_datastore.concrete.models, instance.__class__.__name__
+        )
+        and instance.__class__.__name__
+        not in settings.IGNORED_MODELS_ON_DELETE
+    ):
         # pylint: disable=no-member
         concrete_datastore.concrete.models.DeletedModel.objects.create(
             model_name=instance.__class__.__name__, uid=instance.uid

--- a/concrete_datastore/settings/base.py
+++ b/concrete_datastore/settings/base.py
@@ -470,3 +470,10 @@ DEFAULT_REGISTER_EMAIL_FORMAT = """
 # Flag to allow a user to reuse a password on change, only applicable if
 # current password is not expired
 ALLOW_REUSE_PASSWORD_ON_CHANGE = False
+
+IGNORED_MODELS_ON_DELETE = [
+    "DeletedModel",
+    "AuthToken",
+    "TemporaryToken",
+    "SecureConnectToken",
+]


### PR DESCRIPTION
closes #35 