### PR TITLE
Feature fix stat endpoint return urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- nothing changed
+- Changed the `/stats` enpoint to return proper list of urls
 
 ### Removed
 

--- a/concrete_datastore/api/v1/views.py
+++ b/concrete_datastore/api/v1/views.py
@@ -198,7 +198,7 @@ def apply_filter_since(queryset, timestamp_start, timestamp_end=None):
 
     queryset = queryset.filter(
         modification_date__range=(
-            pendulum.from_timestamp(timestamp_start),
+            pendulum.from_timestamp(parse_to_float(timestamp_start)),
             pendulum.from_timestamp(parse_to_float(timestamp_end)),
         )
     )
@@ -1333,7 +1333,7 @@ class PaginatedViewSet(object):
         queryset = self.filter_queryset(self.get_queryset())
 
         if timestamp_start is not None:
-            timestamp_start = parse_to_float(timestamp_start)
+            timestamp_start = timestamp_start
             queryset, timestamp_end = apply_filter_since(
                 queryset, timestamp_start, timestamp_end
             )

--- a/concrete_datastore/api/v1/views.py
+++ b/concrete_datastore/api/v1/views.py
@@ -6,7 +6,7 @@ import uuid
 import sys
 import re
 import os
-
+import urllib.parse as urlparse
 from urllib.parse import urljoin, unquote
 from importlib import import_module
 from itertools import chain
@@ -199,7 +199,7 @@ def apply_filter_since(queryset, timestamp_start, timestamp_end=None):
     queryset = queryset.filter(
         modification_date__range=(
             pendulum.from_timestamp(timestamp_start),
-            pendulum.from_timestamp(timestamp_end),
+            pendulum.from_timestamp(parse_to_float(timestamp_end)),
         )
     )
     return queryset, timestamp_end
@@ -1268,6 +1268,28 @@ class PaginatedViewSet(object):
         if request.parser_context["view"].model_class.__name__ == "User":
             validate_request_permissions(request=request)
 
+        # Get urls for the subpages from the stats url
+        parsed_url = urlparse.urlparse(self.request.build_absolute_uri())
+        # Delete /stats/ from url
+        parsed_url = parsed_url._replace(
+            path=parsed_url.path.split('stats/')[0]
+        )
+        url_query = parsed_url.query
+        # Reformat timestamps, add them to query params of request
+        if timestamp_start:
+            if url_query == '':
+                url_query = f'timestamp_start={timestamp_start}'
+            else:
+                url_query += f'&timestamp_start={timestamp_start}'
+        if timestamp_end:
+            if url_query == '':
+                url_query = f'timestamp_end={timestamp_end}'
+            else:
+                url_query += f'&timestamp_end={timestamp_end}'
+
+        url = urlparse.urlunparse(parsed_url._replace(query=url_query))
+        print(f'URLLLL:   {url}')
+
         queryset, timestamp_end = self._get_queryset_filtered_since_timestamp(
             timestamp_start, timestamp_end
         )
@@ -1277,18 +1299,12 @@ class PaginatedViewSet(object):
             timestamp_start=timestamp_start,
             timestamp_end=timestamp_end,
         )
+
         _total = queryset.count()
 
         _num_pages = _resp.data['num_total_pages']
 
         dict_pages = dict()
-        base_url, url_suffix = tuple(
-            self.request.build_absolute_uri().rsplit('stats/', 2)
-        )
-        if url_suffix == '':
-            url = base_url
-        else:
-            url = f'{base_url}?{url_suffix.replace(":","=")}'
 
         for page_number in range(1, _num_pages + 1):
             if page_number == 1:

--- a/concrete_datastore/api/v1/views.py
+++ b/concrete_datastore/api/v1/views.py
@@ -1288,7 +1288,6 @@ class PaginatedViewSet(object):
                 url_query += f'&timestamp_end={timestamp_end}'
 
         url = urlparse.urlunparse(parsed_url._replace(query=url_query))
-        print(f'URLLLL:   {url}')
 
         queryset, timestamp_end = self._get_queryset_filtered_since_timestamp(
             timestamp_start, timestamp_end

--- a/concrete_datastore/api/v1/views.py
+++ b/concrete_datastore/api/v1/views.py
@@ -6,8 +6,7 @@ import uuid
 import sys
 import re
 import os
-import urllib.parse as urlparse
-from urllib.parse import urljoin, unquote
+from urllib.parse import urljoin, unquote, urlparse, urlunparse
 from importlib import import_module
 from itertools import chain
 from datetime import date
@@ -1269,7 +1268,7 @@ class PaginatedViewSet(object):
             validate_request_permissions(request=request)
 
         # Get urls for the subpages from the stats url
-        parsed_url = urlparse.urlparse(self.request.build_absolute_uri())
+        parsed_url = urlparse(self.request.build_absolute_uri())
         # Delete /stats/ from url
         parsed_url = parsed_url._replace(
             path=parsed_url.path.split('stats/')[0]
@@ -1287,7 +1286,7 @@ class PaginatedViewSet(object):
             else:
                 url_query += f'&timestamp_end={timestamp_end}'
 
-        url = urlparse.urlunparse(parsed_url._replace(query=url_query))
+        url = urlunparse(parsed_url._replace(query=url_query))
 
         queryset, timestamp_end = self._get_queryset_filtered_since_timestamp(
             timestamp_start, timestamp_end

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     uritemplate>=3.0.0,<4
     # Datamodel parser
     six>=1.12,<2
-    python-slugify>=4.0.0,<5
+    python-slugify>=3.0.3,<4
     # Plugins
     celery>=4.3,<5
     redis>=3.2,<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     uritemplate>=3.0.0,<4
     # Datamodel parser
     six>=1.12,<2
-    python-slugify>=3.0.3,<4
+    python-slugify>=4.0.0,<5
     # Plugins
     celery>=4.3,<5
     redis>=3.2,<4

--- a/tests/tests_api_v1_1/test_api_v1_1_CRUD.py
+++ b/tests/tests_api_v1_1/test_api_v1_1_CRUD.py
@@ -151,8 +151,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': 'http://testserver/api/v1.1/project/stats/',
-            'page2': 'http://testserver/api/v1.1/project/stats/?page=2',
+            'page1': 'http://testserver/api/v1.1/project/',
+            'page2': 'http://testserver/api/v1.1/project/?page=2',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 
@@ -184,8 +184,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': 'http://testserver/api/v1.1/project/stats/timestamp_start:123456789.123/',
-            'page2': 'http://testserver/api/v1.1/project/stats/timestamp_start:123456789.123/?page=2',
+            'page1': 'http://testserver/api/v1.1/project/?timestamp_start=123456789.123/',
+            'page2': 'http://testserver/api/v1.1/project/?page=2&timestamp_start=123456789.123/',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 
@@ -219,8 +219,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': f'http://testserver/api/v1.1/project/stats/timestamp_start:123456789.123/?timestamp_end%3A{ts}%2F=',
-            'page2': f'http://testserver/api/v1.1/project/stats/timestamp_start:123456789.123/?page=2&timestamp_end%3A{ts}%2F=',
+            'page1': f'http://testserver/api/v1.1/project/?timestamp_start=123456789.123/?timestamp_end={ts}/',
+            'page2': f'http://testserver/api/v1.1/project/?page=2&timestamp_start=123456789.123/?timestamp_end={ts}/',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 

--- a/tests/tests_api_v1_1/test_api_v1_1_CRUD.py
+++ b/tests/tests_api_v1_1/test_api_v1_1_CRUD.py
@@ -132,7 +132,7 @@ class CRUDTestCase(APITestCase):
                 description="description du projet {}".format(i),
                 created_by=self.user,
             )
-        url_projects = '/api/v1.1/project/stats/'
+        url_projects = '/api/v1.1/project/stats/?archived=false'
         resp = self.client.get(
             url_projects, {}, HTTP_AUTHORIZATION='Token {}'.format(self.token)
         )
@@ -151,8 +151,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': 'http://testserver/api/v1.1/project/',
-            'page2': 'http://testserver/api/v1.1/project/?page=2',
+            'page1': 'http://testserver/api/v1.1/project/?archived=false',
+            'page2': 'http://testserver/api/v1.1/project/?archived=false&page=2',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 
@@ -184,8 +184,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': 'http://testserver/api/v1.1/project/?timestamp_start=123456789.123/',
-            'page2': 'http://testserver/api/v1.1/project/?page=2&timestamp_start=123456789.123/',
+            'page1': 'http://testserver/api/v1.1/project/?timestamp_start=123456789.123',
+            'page2': 'http://testserver/api/v1.1/project/?page=2&timestamp_start=123456789.123',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 
@@ -200,7 +200,7 @@ class CRUDTestCase(APITestCase):
 
         ts = pendulum.now('utc').timestamp()
 
-        url_projects = f'/api/v1.1/project/stats/timestamp_start:123456789.123/?timestamp_end:{ts}/'
+        url_projects = f'/api/v1.1/project/stats/timestamp_start:123456789.123-timestamp_end:{ts}/'
         resp = self.client.get(
             url_projects, {}, HTTP_AUTHORIZATION='Token {}'.format(self.token)
         )
@@ -219,8 +219,8 @@ class CRUDTestCase(APITestCase):
         self.assertEqual(resp.data['max_allowed_objects_per_page'], 10)
 
         pages_dict = {
-            'page1': f'http://testserver/api/v1.1/project/?timestamp_start=123456789.123/?timestamp_end={ts}/',
-            'page2': f'http://testserver/api/v1.1/project/?page=2&timestamp_start=123456789.123/?timestamp_end={ts}/',
+            'page1': f'http://testserver/api/v1.1/project/?timestamp_end={ts}&timestamp_start=123456789.123',
+            'page2': f'http://testserver/api/v1.1/project/?page=2&timestamp_end={ts}&timestamp_start=123456789.123',
         }
         self.assertDictEqual(resp.data['page_urls'], pages_dict)
 


### PR DESCRIPTION
The stats endpoint was not returning the right urls for the pages. One thing that was wrong was that the `/stats/` where still part of all urls. Moreover, the timestamp start and end were not transformed to query params.

Closes #22 