### PR TITLE
Changed validation error format, avoid single `%` in `format` args (C…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- nothing changed
+- Changed validation error format, avoid single `%` in `format` args (Correct error 500 while creating user in Admin)
 
 ### Removed
 

--- a/concrete_datastore/concrete/password.py
+++ b/concrete_datastore/concrete/password.py
@@ -184,7 +184,7 @@ class PasswordMinSpecialValidation(object):
                     " character(s) from these : {special_list}"
                 ).format(
                     min_special=self.min_special,
-                    special_list=''.join(set(settings.SPECIAL_CHARACTERS)),
+                    special_list=settings.SPECIAL_CHARACTERS,
                 ),
                 code=self.code,
                 params={'min_special': self.min_special},

--- a/tests/test_admin_forms.py
+++ b/tests/test_admin_forms.py
@@ -61,3 +61,32 @@ class MyCreationUserFormTest(TestCase):
             instance=self.user,
         )
         test_creation_form.save()
+
+    @override_settings(
+        PASSWORD_MIN_SPECIAL=1,
+    )
+    def test_creation_user(self):
+        test_creation_form = MyCreationUserForm(
+            {
+                "email": "bbb@netsach.org",
+                "password1": "test@",
+                "password2": "test@",
+            },
+            instance=self.user,
+        )
+        self.assertTrue(test_creation_form.is_valid())
+
+    @override_settings(
+        PASSWORD_MIN_SPECIAL=1, SPECIAL_CHARACTERS="!@#$%%^&*()_+-=[]{}|'\""
+    )
+    def test_creation_user(self):
+        test_creation_form = MyCreationUserForm(
+            {
+                "email": "bbb@netsach.org",
+                "password1": "test",
+                "password2": "test",
+            },
+            instance=self.user,
+        )
+        self.assertFalse(test_creation_form.is_valid())
+        self.assertNotEqual(str(test_creation_form.errors), '')

--- a/tests/tests_api_v1_0/test_api_v1_0_email.py
+++ b/tests/tests_api_v1_0/test_api_v1_0_email.py
@@ -59,7 +59,7 @@ class EmailTest(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED, resp.data)
         self.assertIn('resource_status', resp.data)
-        self.assertEqual(resp.data['resource_status'], 'sent')
+        self.assertEqual(resp.data['resource_status'], 'sent', resp.data)
 
         self.assertIn('uid', resp.data)
         instance_mail = Email.objects.get(uid=resp.data['uid'])

--- a/tests/tests_api_v1_1/test_password_validation.py
+++ b/tests/tests_api_v1_1/test_password_validation.py
@@ -178,5 +178,5 @@ class PasswordValidationTestCase(TestCase):
             (
                 "The password must contain at least 1 special"
                 " character(s) from these : {special_list}"
-            ).format(special_list=''.join(set(settings.SPECIAL_CHARACTERS))),
+            ).format(special_list=settings.SPECIAL_CHARACTERS),
         )


### PR DESCRIPTION
…orrect error 500 while creating user in Admin)