### PR TITLE
raise an exception if a minimum creation level on any instance is set to Anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- When parsing the datamodel, raise an exception if a minimum creation level on any instance is set to Anonymous.
+- When parsing the datamodel, raise an error if a minimum creation level on any instance is set to Anonymous.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- nothing added
+- When parsing the datamodel, raise an exception if a minimum creation level on any instance is set to Anonymous.
 
 ### Changed
 

--- a/concrete_datastore/parsers/exceptions.py
+++ b/concrete_datastore/parsers/exceptions.py
@@ -160,7 +160,7 @@ class DuplicatedModelError(Exception):
     pass
 
 
-class AnonymousNotAllowedToCreate(ModelManagerGenericException):
+class AnonymousNotAllowedToCreateError(ModelManagerGenericException):
     code = "ANONYMOUS_NOT_ALLOWED_TO_CREATE"
     message = (
         "Create should be at least authenticated. "

--- a/concrete_datastore/parsers/exceptions.py
+++ b/concrete_datastore/parsers/exceptions.py
@@ -158,3 +158,11 @@ class DuplicatedModelError(Exception):
     """
 
     pass
+
+
+class AnonymousNotAllowedToCreate(ModelManagerGenericException):
+    code = "ANONYMOUS_NOT_ALLOWED_TO_CREATE"
+    message = (
+        "Create should be at least authenticated. "
+        "For security issues, Anonymous users cannot create instances."
+    )

--- a/concrete_datastore/parsers/meta.py
+++ b/concrete_datastore/parsers/meta.py
@@ -20,7 +20,7 @@ from concrete_datastore.parsers.exceptions import (
     ProtectedModelNameError,
     ProtectedFieldNameError,
     UnknownIPProtocol,
-    AnonymousNotAllowedToCreate,
+    AnonymousNotAllowedToCreateError,
 )
 from concrete_datastore.parsers.validators import validate_specifier
 from concrete_datastore.parsers.constants import (
@@ -137,8 +137,8 @@ def make_modelisation_cls(modelisation_spec, version, base=Model):
         minimum_levels = {}
         for perm, level in permission_dict['minimum_levels'].items():
             if perm == 'create' and level == "anonymous":
-                #: Raise exception if minimum create level is anonymous
-                raise AnonymousNotAllowedToCreate()
+                #: Raise error if minimum create level is anonymous
+                raise AnonymousNotAllowedToCreateError()
             key = 'creation' if perm == 'create' else perm
             minimum_levels.update({f'm_{key}_minimum_level': level})
         return minimum_levels

--- a/concrete_datastore/parsers/meta.py
+++ b/concrete_datastore/parsers/meta.py
@@ -20,6 +20,7 @@ from concrete_datastore.parsers.exceptions import (
     ProtectedModelNameError,
     ProtectedFieldNameError,
     UnknownIPProtocol,
+    AnonymousNotAllowedToCreate,
 )
 from concrete_datastore.parsers.validators import validate_specifier
 from concrete_datastore.parsers.constants import (
@@ -135,6 +136,9 @@ def make_modelisation_cls(modelisation_spec, version, base=Model):
             raise UnknownDatamodelVersionError()
         minimum_levels = {}
         for perm, level in permission_dict['minimum_levels'].items():
+            if perm == 'create' and level == "anonymous":
+                #: Raise exception if minimum create level is anonymous
+                raise AnonymousNotAllowedToCreate()
             key = 'creation' if perm == 'create' else perm
             minimum_levels.update({f'm_{key}_minimum_level': level})
         return minimum_levels


### PR DESCRIPTION
There is no check if the user is authenticated for creating instances on concrete datastore, so if the datamodel specifies `anonymous` as the minimum level for creation, the ForeingKey `created_by` will fail with 
```
ValueError: Cannot assign "<django.contrib.auth.models.AnonymousUser object at 0x7f1fcdab1f10>": "<Model>.created_by" must be a "User" instance.
```