### PR TITLE
Add deleted uids for users request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- nothing added
+- Deleted uids for blocked users for requests with a timestamp
 
 ### Changed
 

--- a/concrete_datastore/api/v1/views.py
+++ b/concrete_datastore/api/v1/views.py
@@ -1798,6 +1798,19 @@ class PaginatedViewSet(object):
                         excl_modified_instances.values_list('uid', flat=True),
                     )
                 )
+                model_name = queryset.model.__name__
+                if model_name.lower() == 'user':
+                    # Add deleted uids for model user
+                    # with blocked users
+                    deleted_users_uids, _ = apply_filter_since(
+                        UserModel.objects.filter(is_active=False),
+                        timestamp_start,
+                        timestamp_end,
+                    )
+                    deleted_uids.update(
+                        deleted_users_uids.values_list('uid', flat=True)
+                    )
+
                 deleted_uids = list(deleted_uids)
 
             extra_informations.update(

--- a/tests/tests_api_v1_1/test_api_v1_1_filter_and_timestamp.py
+++ b/tests/tests_api_v1_1/test_api_v1_1_filter_and_timestamp.py
@@ -10,7 +10,7 @@ from django.test import override_settings
 class TimestampTestCase(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user('johndoe@netsach.org')
-        self.user.is_superuser = True
+        self.user.set_level('superuser')
         self.user.set_password('plop')
         self.user.save()
         confirmation = UserConfirmation.objects.create(user=self.user)
@@ -173,6 +173,157 @@ class TimestampTestCase(APITestCase):
 
         resp = self.client.get(
             url_projects_T6, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertListEqual(resp.data['deleted_uids'], [])
+        self.assertEqual(resp.data['objects_count'], 0)
+        self.assertEqual(resp.data['total_objects_count'], 4)
+
+    def test_filter_and_incremental_loading_for_users(self):
+        url_users = "/api/v1.1/user/"
+
+        for i in range(4):
+            u = User.objects.create_user(email=f'testuser{i}@netsach.com')
+            u.set_level('manager')
+            u.save()
+        self.assertEqual(User.objects.filter(is_staff=True).count(), 5)
+
+        #: T0: INITIAL LOADING
+
+        url_users_T0 = "/api/v1.1/user/?timestamp_start=0&atleast=manager"
+
+        resp = self.client.get(
+            url_users_T0, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertEqual(
+            resp.status_code, status.HTTP_200_OK, msg=resp.content
+        )
+
+        self.assertEqual(resp.data['deleted_uids'], [])
+        self.assertEqual(resp.data['total_objects_count'], 5, msg=resp.data)
+        self.assertEqual(resp.data['objects_count'], 5, msg=resp.data)
+        T0_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T1 : INCREMENTAL LOADING
+        #:      No modifications performed
+        url_users_T1 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T0_timestamp_end)
+        )
+        resp = self.client.get(
+            url_users_T1, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertEqual(resp.data['deleted_uids'], [])
+        self.assertEqual(resp.data['objects_count'], 0)
+        self.assertEqual(resp.data['total_objects_count'], 5)
+        T1_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T2 : INCREMENTAL LOADING
+        #:      Updated 1 user (manager -> simpleuser)
+
+        u = User.objects.filter(email='testuser1@netsach.com').first()
+        u.set_level('simpleuser')
+        u.save()
+
+        url_users_T2 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T1_timestamp_end)
+        )
+
+        resp = self.client.get(
+            url_users_T2, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertListEqual(resp.data['deleted_uids'], [u.uid])
+        self.assertEqual(resp.data['objects_count'], 0)
+        self.assertEqual(resp.data['total_objects_count'], 4)
+        T2_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T3 : INCREMENTAL LOADING
+        #:      Block 1 user
+
+        u = User.objects.filter(email='testuser2@netsach.com').first()
+        user_uid = u.uid
+        u.set_level('blocked')
+        u.save()
+
+        url_users_T3 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T2_timestamp_end)
+        )
+
+        resp = self.client.get(
+            url_users_T3, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertListEqual(resp.data['deleted_uids'], [user_uid])
+        self.assertEqual(resp.data['objects_count'], 0)
+        self.assertEqual(resp.data['total_objects_count'], 3)
+        T3_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T4 : INCREMENTAL LOADING
+        #:      Added 1 user
+
+        u = User.objects.create(email='test7@netsach.com')
+        u.set_level('manager')
+        u.save()
+
+        url_users_T4 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T3_timestamp_end)
+        )
+
+        resp = self.client.get(
+            url_users_T4, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertListEqual(resp.data['deleted_uids'], [])
+        self.assertEqual(resp.data['objects_count'], 1)
+        self.assertEqual(resp.data['total_objects_count'], 4)
+        T4_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T5 : INCREMENTAL LOADING
+        #:      Added 1 non matching user, expected: found in deleted_uids
+
+        u = User.objects.create(email='test8@netsach.com')
+
+        url_users_T5 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T4_timestamp_end)
+        )
+
+        resp = self.client.get(
+            url_users_T5, HTTP_AUTHORIZATION='Token {}'.format(self.token)
+        )
+        self.assertListEqual(resp.data['deleted_uids'], [u.uid])
+        self.assertEqual(resp.data['objects_count'], 0)
+        self.assertEqual(resp.data['total_objects_count'], 4)
+        T5_timestamp_end = resp.data['timestamp_end']
+        time.sleep(0.5)
+
+        #: --------------------------------------------------------------------
+
+        #: T6 : INCREMENTAL LOADING
+        #:      doing nothing, expected: no change
+
+        url_users_T6 = (
+            "/api/v1.1/user/"
+            "?timestamp_start={}&atleast=manager".format(T5_timestamp_end)
+        )
+
+        resp = self.client.get(
+            url_users_T6, HTTP_AUTHORIZATION='Token {}'.format(self.token)
         )
         self.assertListEqual(resp.data['deleted_uids'], [])
         self.assertEqual(resp.data['objects_count'], 0)


### PR DESCRIPTION
The request to the model user was missing deleted uids for blocked users. So the blocked users were not removed from the cache data